### PR TITLE
feat: amcl publish residual errors

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -188,6 +188,8 @@ protected:
     pose_pub_;
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::ParticleCloud>::SharedPtr
     particle_cloud_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::LaserScan>::SharedPtr
+    residual_errors_pub_;
   /*
    * @brief Handle with an initial pose estimate is received
    */
@@ -286,6 +288,14 @@ protected:
   rclcpp::Time last_laser_received_ts_;
 
   /*
+   * @brief Get laser data from the laser scan
+   */
+  bool getLaserData(
+    const int & laser_index,
+    const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
+    nav2_amcl::LaserData & ldata);
+
+  /*
    * @brief Check if sufficient time has elapsed to get an update
    */
   bool checkElapsedTime(std::chrono::seconds check_interval, rclcpp::Time last_time);
@@ -305,9 +315,9 @@ protected:
   /*
    * @brief Update the PF
    */
-  bool updateFilter(
+  void updateFilter(
     const int & laser_index,
-    const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
+    nav2_amcl::LaserData & ldata,
     const pf_vector_t & pose);
   /*
    * @brief Publish particle cloud
@@ -325,6 +335,13 @@ protected:
   void publishAmclPose(
     const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
     const std::vector<amcl_hyp_t> & hyps, const int & max_weight_hyp);
+  /*
+    * @brief Get the residual errors of the scan points with respect to the map
+    */
+   void publishResidualErors(
+    const std::vector<amcl_hyp_t> & hyps, const int & max_weight_hyp,
+    nav2_amcl::LaserData & ldata, const int & laser_index,
+    const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan);
   /*
    * @brief Determine TF transformation from map to odom
    */

--- a/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
+++ b/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
@@ -62,6 +62,11 @@ public:
    */
   void SetLaserPose(pf_vector_t & laser_pose);
 
+  /*
+   * @brief Get the laser endpoints errors with respect to the map
+   */
+  void getResidualErors(const pf_vector_t & pose, const LaserData * laser_data, float * residuals);
+
 protected:
   double z_hit_;
   double z_rand_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -273,6 +273,7 @@ AmclNode::on_activate(const rclcpp_lifecycle::State & /*state*/)
   // Lifecycle publishers must be explicitly activated
   pose_pub_->on_activate();
   particle_cloud_pub_->on_activate();
+  residual_errors_pub_->on_activate();
 
   first_pose_sent_ = false;
 
@@ -322,6 +323,7 @@ AmclNode::on_deactivate(const rclcpp_lifecycle::State & /*state*/)
   // Lifecycle publishers must be explicitly deactivated
   pose_pub_->on_deactivate();
   particle_cloud_pub_->on_deactivate();
+  residual_errors_pub_->on_deactivate();
 
   // reset dynamic parameter handler
   dyn_params_handler_.reset();
@@ -698,10 +700,14 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
   }
 
   bool resampled = false;
+  nav2_amcl::LaserData ldata;
 
   // If the robot has moved, update the filter
   if (lasers_update_[laser_index]) {
-    updateFilter(laser_index, laser_scan, pose);
+    if (!getLaserData(laser_index, laser_scan, ldata))
+      return;
+
+    updateFilter(laser_index, ldata, pose);
 
     // Resample the particles
     if (!(++resample_count_ % resample_interval_)) {
@@ -722,6 +728,7 @@ AmclNode::laserReceived(sensor_msgs::msg::LaserScan::ConstSharedPtr laser_scan)
     int max_weight_hyp = -1;
     if (getMaxWeightHyp(hyps, max_weight_hyps, max_weight_hyp)) {
       publishAmclPose(laser_scan, hyps, max_weight_hyp);
+      publishResidualErors(hyps, max_weight_hyp, ldata, laser_index, laser_scan);
       calculateMaptoOdomTransform(laser_scan, hyps, max_weight_hyp);
 
       if (tf_broadcast_ == true) {
@@ -795,12 +802,11 @@ bool AmclNode::shouldUpdateFilter(const pf_vector_t pose, pf_vector_t & delta)
   return update;
 }
 
-bool AmclNode::updateFilter(
+bool AmclNode::getLaserData(
   const int & laser_index,
   const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan,
-  const pf_vector_t & pose)
+  nav2_amcl::LaserData & ldata)
 {
-  nav2_amcl::LaserData ldata;
   ldata.laser = lasers_[laser_index];
   ldata.range_count = laser_scan->ranges.size();
   // To account for lasers that are mounted upside-down, we determine the
@@ -861,10 +867,17 @@ bool AmclNode::updateFilter(
     ldata.ranges[i][1] = angle_min +
       (i * angle_increment);
   }
+  return true;
+}
+
+void AmclNode::updateFilter(
+  const int & laser_index,
+  nav2_amcl::LaserData & ldata,
+  const pf_vector_t & pose)
+{
   lasers_[laser_index]->sensorUpdate(pf_, reinterpret_cast<nav2_amcl::LaserData *>(&ldata));
   lasers_update_[laser_index] = false;
   pf_odom_pose_ = pose;
-  return true;
 }
 
 void
@@ -987,6 +1000,31 @@ AmclNode::publishAmclPose(
     hyps[max_weight_hyp].pf_pose_mean.v[0],
     hyps[max_weight_hyp].pf_pose_mean.v[1],
     hyps[max_weight_hyp].pf_pose_mean.v[2]);
+}
+
+void
+AmclNode::publishResidualErors(
+  const std::vector<amcl_hyp_t> & hyps, const int & max_weight_hyp,
+  nav2_amcl::LaserData & ldata, const int & laser_index,
+  const sensor_msgs::msg::LaserScan::ConstSharedPtr & laser_scan)
+{
+  pf_vector_t pose;
+  pose.v[0] = hyps[max_weight_hyp].pf_pose_mean.v[0];
+  pose.v[1] = hyps[max_weight_hyp].pf_pose_mean.v[1];
+  pose.v[2] = hyps[max_weight_hyp].pf_pose_mean.v[2];
+
+  float * residual_errors = new float[ldata.range_count];
+
+  lasers_[laser_index]->getResidualErors(pose , &ldata, residual_errors);
+
+  std::vector<float> residual_errors_vector(residual_errors, residual_errors + ldata.range_count);
+  delete[] residual_errors;
+
+  auto residual_scan = *laser_scan.get();
+  residual_scan.intensities.resize(ldata.range_count);
+  residual_scan.intensities = residual_errors_vector;
+
+  residual_errors_pub_->publish(std::move(residual_scan));
 }
 
 void
@@ -1547,6 +1585,10 @@ AmclNode::initPubSub()
 
   pose_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "amcl_pose",
+    rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+
+  residual_errors_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
+    "residual_errors",
     rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
 
   initial_pose_sub_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(

--- a/nav2_amcl/src/sensors/laser/laser.cpp
+++ b/nav2_amcl/src/sensors/laser/laser.cpp
@@ -70,4 +70,41 @@ Laser::SetLaserPose(pf_vector_t & laser_pose)
   laser_pose_ = laser_pose;
 }
 
+void
+Laser::getResidualErors(const pf_vector_t & pose, const LaserData * laser_data, float * residuals)
+{
+  pf_vector_t updated_pose = pf_vector_coord_add(laser_pose_, pose);
+  for (int i = 0; i < laser_data->range_count; i++) {
+    // Get the range and angle
+    double obs_range = laser_data->ranges[i][0];
+    double obs_bearing = laser_data->ranges[i][1];
+
+    if (obs_range >= laser_data->range_max) {
+      residuals[i] = -1;
+      continue;
+    }
+
+    // Check for NaN
+    if (obs_range != obs_range) {
+      residuals[i] = -1;
+      continue;
+    }
+
+    // Transform the point into the map frame
+    double x = updated_pose.v[0] + obs_range * cos(updated_pose.v[2] + obs_bearing);
+    double y = updated_pose.v[1] + obs_range * sin(updated_pose.v[2] + obs_bearing);
+
+    int mi, mj;
+    mi = MAP_GXWX(map_, x);
+    mj = MAP_GYWY(map_, y);
+
+    // Get the distance to the nearest obstacle
+    if (!MAP_VALID(map_, mi, mj)) {
+      residuals[i] = -1;
+    } else {
+      residuals[i] = map_->cells[MAP_INDEX(map_, mi, mj)].occ_dist;
+    }
+  }
+}
+
 }  // namespace nav2_amcl


### PR DESCRIPTION
Publish residual errors of laser scans defined by the distance between the endpoint and nearest landscape on the static map. This will be used in Markov Random Field localization failure detector implemented here: https://github.com/NaokiAkai/als_ros