### PR TITLE
Feat(amcl)  max distance to consider occlusion

### DIFF
--- a/nav2_amcl/include/nav2_amcl/amcl_node.hpp
+++ b/nav2_amcl/include/nav2_amcl/amcl_node.hpp
@@ -392,6 +392,7 @@ protected:
   double beam_skip_error_threshold_;
   double beam_skip_threshold_;
   bool do_beamskip_;
+  double occlusion_max_distance_;
   double occlusion_distance_tolerance_;
   double occlusion_angular_tolerance_;
   std::string global_frame_id_;

--- a/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
+++ b/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
@@ -68,14 +68,13 @@ public:
   void getResidualErors(const pf_vector_t & pose, const LaserData * laser_data, float * residuals);
 
   /*
-  * @brief Get the occluded scans in the laser data, occlusion data is encoded as: {-1 = invalid; 0 = valid; 1 = occluded}
+   * @brief Get the occluded scans in the laser data, occlusion data is encoded as: {-1 = invalid; 0 = not occluded; 1 = occluded}
    * @param pose Pose of the laser
    * @param laser_data Laser data to use
    * @param max_dist Maximum distance to consider for occlusion
    * @param dist_tol Distance tolerance to consider for occlusion
    * @param angular_tol Angular tolerance to consider for occlusion
    * @param occlusions Output array of occlusion data
-   * @return pointer to occlusions array
   */
   void getOcclusions(
     const pf_vector_t & pose,

--- a/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
+++ b/nav2_amcl/include/nav2_amcl/sensors/laser/laser.hpp
@@ -68,10 +68,22 @@ public:
   void getResidualErors(const pf_vector_t & pose, const LaserData * laser_data, float * residuals);
 
   /*
-  * @brief Get the occluded scans in the laser data
+  * @brief Get the occluded scans in the laser data, occlusion data is encoded as: {-1 = invalid; 0 = valid; 1 = occluded}
+   * @param pose Pose of the laser
+   * @param laser_data Laser data to use
+   * @param max_dist Maximum distance to consider for occlusion
+   * @param dist_tol Distance tolerance to consider for occlusion
+   * @param angular_tol Angular tolerance to consider for occlusion
+   * @param occlusions Output array of occlusion data
+   * @return pointer to occlusions array
   */
   void getOcclusions(
-    const pf_vector_t & pose, const LaserData * laser_data, float dist_tol, float angular_tol, bool * occlusions);
+    const pf_vector_t & pose,
+    const LaserData * laser_data,
+    float max_dist,
+    float dist_tol,
+    float angular_tol, 
+    int8_t * occlusions);
 
 protected:
   double z_hit_;

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1079,6 +1079,9 @@ AmclNode::publishOcclusionScore(
   delete[] occlusions;
 
   float occlusion_score = static_cast<float>(occluded_beams) / static_cast<float>(occluded_beams + valid_beams);
+  const int considered_beams = occluded_beams + valid_beams;
+  float occlusion_score =
+    considered_beams > 0 ? static_cast<float>(occluded_beams) / static_cast<float>(considered_beams) : 0.0f;
 
   auto occlusion_msg = std::make_unique<std_msgs::msg::Float32>();
   occlusion_msg->data = occlusion_score;
@@ -1364,6 +1367,9 @@ AmclNode::dynamicParametersCallback(
         reinit_laser = true;
       } else if (param_name == "occlusion_max_distance") {
         occlusion_max_distance_ = parameter.as_double();
+        if (occlusion_max_distance_ < 0.0) {
+           occlusion_max_distance_ = std::numeric_limits<double>::infinity();
+        }
       } else if (param_name == "occlusion_distance_tolerance") {
         occlusion_distance_tolerance_ = parameter.as_double();
       } else if (param_name == "occlusion_angular_tolerance") {

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -94,6 +94,11 @@ AmclNode::AmclNode(const rclcpp::NodeOptions & options)
   add_parameter("do_beamskip", rclcpp::ParameterValue(false));
 
   add_parameter(
+    "occlusion_max_distance", rclcpp::ParameterValue(-1.0),
+    "Maximum distance to check for occlusions, in meters. Set to -1 to remove limit"
+  );
+  
+  add_parameter(
     "occlusion_distance_tolerance", rclcpp::ParameterValue(0.05),
     "Distance tolerance in meters when checking for occlusions");
 
@@ -1054,22 +1059,26 @@ AmclNode::publishOcclusionScore(
   pose.v[0] = max_hyp.pf_pose_mean.v[0];
   pose.v[1] = max_hyp.pf_pose_mean.v[1];
   pose.v[2] = max_hyp.pf_pose_mean.v[2];
-  bool * occlusions = new bool[ldata.range_count];
+  int8_t * occlusions = new int8_t[ldata.range_count];
   lasers_[laser_index]->getOcclusions(
-    pose, &ldata, occlusion_distance_tolerance_, occlusion_angular_tolerance_, occlusions);
+    pose, &ldata, occlusion_max_distance_, occlusion_distance_tolerance_, occlusion_angular_tolerance_, occlusions);
 
   int occluded_beams = 0;
+  int valid_beams = 0;
   sensor_msgs::msg::LaserScan occlusion_scan = *laser_scan.get();
   for (int i = 0; i < ldata.range_count; i++) {
-    if (occlusions[i]) {
+    if (occlusions[i] == 1) {
       occluded_beams++;
-    } else {
-      occlusion_scan.ranges[i] = std::numeric_limits<float>::quiet_NaN();
+      continue;
     }
+    if (occlusions[i] == 0) {
+      valid_beams++;
+    }
+    occlusion_scan.ranges[i] = std::numeric_limits<float>::quiet_NaN();
   }
   delete[] occlusions;
 
-  float occlusion_score = static_cast<float>(occluded_beams) / static_cast<float>(ldata.range_count);
+  float occlusion_score = static_cast<float>(occluded_beams) / static_cast<float>(occluded_beams + valid_beams);
 
   auto occlusion_msg = std::make_unique<std_msgs::msg::Float32>();
   occlusion_msg->data = occlusion_score;
@@ -1160,6 +1169,7 @@ AmclNode::initParameters()
   get_parameter("beam_skip_error_threshold", beam_skip_error_threshold_);
   get_parameter("beam_skip_threshold", beam_skip_threshold_);
   get_parameter("do_beamskip", do_beamskip_);
+  get_parameter("occlusion_max_distance", occlusion_max_distance_);
   get_parameter("occlusion_distance_tolerance", occlusion_distance_tolerance_);
   get_parameter("occlusion_angular_tolerance", occlusion_angular_tolerance_);
   get_parameter("global_frame_id", global_frame_id_);
@@ -1244,6 +1254,10 @@ AmclNode::initParameters()
       get_logger(), "You've set resample_interval to be zero or negative,"
       " this isn't allowed so it will be set to default value to 1.");
     resample_interval_ = 1;
+  }
+
+  if (occlusion_max_distance_ < 0) {
+    occlusion_max_distance_ = std::numeric_limits<double>::infinity();
   }
 
   if (always_reset_initial_pose_) {

--- a/nav2_amcl/src/amcl_node.cpp
+++ b/nav2_amcl/src/amcl_node.cpp
@@ -1362,6 +1362,12 @@ AmclNode::dynamicParametersCallback(
       } else if (param_name == "laser_min_range") {
         laser_min_range_ = parameter.as_double();
         reinit_laser = true;
+      } else if (param_name == "occlusion_max_distance") {
+        occlusion_max_distance_ = parameter.as_double();
+      } else if (param_name == "occlusion_distance_tolerance") {
+        occlusion_distance_tolerance_ = parameter.as_double();
+      } else if (param_name == "occlusion_angular_tolerance") {
+        occlusion_angular_tolerance_ = parameter.as_double();
       } else if (param_name == "pf_err") {
         pf_err_ = parameter.as_double();
         reinit_pf = true;

--- a/nav2_amcl/src/sensors/laser/laser.cpp
+++ b/nav2_amcl/src/sensors/laser/laser.cpp
@@ -124,7 +124,7 @@ Laser::getOcclusions(
     double bearing [] = {obs_bearing - angular_tol, obs_bearing, obs_bearing + angular_tol};
     double max_map_range = std::numeric_limits<double>::min();
 
-    if (obs_range > max_dist || obs_range != obs_range) {
+    if (obs_range > max_dist || obs_range != obs_range || !std::isfinite(obs_range)) {
       occlusions[i] = -1;
       continue;
     }

--- a/nav2_amcl/src/sensors/laser/laser.cpp
+++ b/nav2_amcl/src/sensors/laser/laser.cpp
@@ -124,7 +124,7 @@ Laser::getOcclusions(
     double bearing [] = {obs_bearing - angular_tol, obs_bearing, obs_bearing + angular_tol};
     double max_map_range = std::numeric_limits<double>::min();
 
-    if (obs_range > max_dist) {
+    if (obs_range > max_dist || obs_range != obs_range) {
       occlusions[i] = -1;
       continue;
     }

--- a/nav2_amcl/src/sensors/laser/laser.cpp
+++ b/nav2_amcl/src/sensors/laser/laser.cpp
@@ -108,7 +108,13 @@ Laser::getResidualErors(const pf_vector_t & pose, const LaserData * laser_data, 
 }
 
 void
-Laser::getOcclusions(const pf_vector_t & pose, const LaserData * laser_data, float dist_tol, float angular_tol, bool * occlusions)
+Laser::getOcclusions(
+  const pf_vector_t & pose,
+  const LaserData * laser_data,
+  float max_dist,
+  float dist_tol,
+  float angular_tol,
+  int8_t * occlusions)
 {
   pf_vector_t updated_pose = pf_vector_coord_add(laser_pose_, pose);
 
@@ -117,6 +123,11 @@ Laser::getOcclusions(const pf_vector_t & pose, const LaserData * laser_data, flo
     double obs_bearing = laser_data->ranges[i][1];
     double bearing [] = {obs_bearing - angular_tol, obs_bearing, obs_bearing + angular_tol};
     double max_map_range = std::numeric_limits<double>::min();
+
+    if (obs_range > max_dist) {
+      occlusions[i] = -1;
+      continue;
+    }
 
     for (int b = 0; b < 3; b++) {
       if (obs_range > laser_data->range_max) {
@@ -138,9 +149,9 @@ Laser::getOcclusions(const pf_vector_t & pose, const LaserData * laser_data, flo
 
     // If occlusion is detected, count it
     if (max_map_range < obs_range - dist_tol) {
-      occlusions[i] = true;
+      occlusions[i] = 1;
     } else {
-      occlusions[i] = false;
+      occlusions[i] = 0;
     }
   }
 }


### PR DESCRIPTION
Dans cette PR on ajoute une catégorie dans le calcul d'occlusions : {occlusion, pas d'occlusion, invalide}. Les points invalide comprennent les valeurs infinies et nan en plus des points à l'extérieur du nouveau paramètre occlusion_max_range.

Le calcul du score d'occlusion se fait seulement sur les points valide.